### PR TITLE
RFM12B Library Ehancements

### DIFF
--- a/RFM12B.cpp
+++ b/RFM12B.cpp
@@ -308,6 +308,16 @@ bool RFM12B::CanSend() {
   return false;
 }
 
+bool RFM12B::ClearToSend() {
+  // no need to test with interrupts disabled: state TXRECV is only reached
+  // outside of ISR and we don't care if rxfill jumps from 0 to 1 here
+  if (rxstate == TXRECV && rxfill == 0 && (Byte(0x00) & (RF_RSSI_BIT >> 8)) == 0) {
+    return true;
+  }
+  return false;
+}
+
+
 void RFM12B::SendStart(uint8_t toNodeID, bool requestACK, bool sendACK) {
   rf12_hdr1 = toNodeID | (sendACK ? RF12_HDR_ACKCTLMASK : 0);
   rf12_hdr2 = nodeID | (requestACK ? RF12_HDR_ACKCTLMASK : 0);

--- a/RFM12B.h
+++ b/RFM12B.h
@@ -195,6 +195,7 @@ class RFM12B
     static void ReceiveStart();
     bool ReceiveComplete();
     bool CanSend();
+    bool ClearToSend();
     uint16_t Control(uint16_t cmd);
     void ReceiveCallBack(void (*receivefunction)(void)); 
     

--- a/keywords.txt
+++ b/keywords.txt
@@ -15,6 +15,7 @@ Control	KEYWORD2
 ReceiveStart	KEYWORD2
 ReceiveComplete	KEYWORD2
 CanSend	KEYWORD2
+ClearToSend	KEYWORD2
 SendStart	KEYWORD2
 SendACK	KEYWORD2
 SendWait	KEYWORD2


### PR DESCRIPTION
There are a couple of enhancements that I made to the library for my own purposes that I don't believe impact the library negatively except for one item.  Since power isn't an issue with my use, but speed and packet reliability is, here are the additions that I applied:

1) During the packet send routine, it will not return until the packet has been send.  I changed that to return immediately if no sleep mode was specified.  This allows my code to continue doing other things while the module is provided data by the interrupt routine.

2) When a send is completely by the Interrupt routine, instead of going to TXIDLE, I forced it to go into receive mode.  This may be detrimental for battery applications so some additional code checking for a sleep state and conditionally going to a receive mode is probably needed here.  I added this because I wanted to make sure that the RFM12B was listening at all times except during transmit.

3) Finally, I added a function for setting a receive call back function and then if it is set, then it is called as part of ReceiveComplete function.  I noticed that if the receiver is active when send function is called, allof that data will be lost.  With a call back function, that data can be saved.  In my code, I call ReceiveComplete as part of the main loop, but actually handle the packet received in the callback function.   If a callback function is not defined, functionally is the same as before.  The only restriction is that the callback function cannot call the library's send function or the original data trying to be sent will be overwritten.

I have not tested this code with any of the examples, but other than a power drain in item #2, the changes I have made should not impact anything else.

In my project, power isn't an issue with my use, but speed and packet reliability is.  I have been trying to make the RFM12B work as well as the XBEE modules, but so far there is very little tolerance for RF packet collisions.   My (non library) software has to do quite a lot to track packets and retransmit.  Unfortunately, the more RFM12B modules are active, the higher the collision rates get.

Thanks for the library, I hope these additions can help.
